### PR TITLE
Improve Pastebin.com detection by using a regex

### DIFF
--- a/src/logs.ts
+++ b/src/logs.ts
@@ -226,7 +226,7 @@ const providers: LogProvider[] = [
 ];
 
 export async function parseLog(s: string): Promise<EmbedBuilder | null> {
-  if (s.includes('https://pastebin.com/')) {
+  if (/(https?:\/\/)?pastebin\.com\/(raw\/)?[^/\s]{8}/g.test(s)) {
     const embed = new EmbedBuilder()
       .setTitle('pastebin.com detected')
       .setDescription(


### PR DESCRIPTION
Signed-off-by: pandaninjas <101084582+pandaninjas@users.noreply.github.com>

Examples of what the regex matches and doesn't match
![image](https://user-images.githubusercontent.com/101084582/200190911-1446535b-e344-4ba9-ab10-88194fc4bba6.png)
