### PR TITLE
feat: rory command!!!

### DIFF
--- a/src/_reupload.ts
+++ b/src/_reupload.ts
@@ -49,6 +49,9 @@ export const reuploadCommands = async () => {
       .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
       .setDMPermission(false),
     new SlashCommandBuilder().setName('joke').setDescription("it's a joke"),
+    new SlashCommandBuilder().setName('rory').setDescription("Gets a Rory photo!")
+      .addStringOption((option) =>
+        option.setName("id").setDescription("specify a Rory ID").setRequired(false)),
   ].map((command) => command.toJSON());
 
   const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN!);

--- a/src/commands/rory.ts
+++ b/src/commands/rory.ts
@@ -1,0 +1,51 @@
+import type { CacheType, ChatInputCommandInteraction } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
+
+export interface RoryResponse {
+  /**
+   * The ID of this Rory
+   */
+  id: number;
+  /**
+   * The URL to the image of this Rory
+   */
+  url: string;
+  /**
+   * When error :(
+   */
+  error: string | undefined;
+}
+
+export const roryCommand = async (
+  i: ChatInputCommandInteraction<CacheType>
+) => {
+  await i.deferReply();
+
+  const { value: id } = i.options.get('id') ?? { value: '' };
+
+  const rory: RoryResponse = await fetch(`https://rory.cat/purr/${id}`, {
+    headers: { Accept: 'application/json' },
+  }).then((r) => r.json());
+
+  if (rory.error) {
+    await i.editReply({
+      embeds: [
+        new EmbedBuilder().setTitle('Error!').setDescription(rory.error),
+      ],
+    });
+
+    return;
+  }
+
+  await i.editReply({
+    embeds: [
+      new EmbedBuilder()
+        .setTitle('Rory :3')
+        .setURL(`https://rory.cat/id/${rory.id}`)
+        .setImage(rory.url)
+        .setFooter({
+          text: `ID ${rory.id}`,
+        }),
+    ],
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { starsCommand } from './commands/stars';
 import { modrinthCommand } from './commands/modrinth';
 import { tagsCommand } from './commands/tags';
 import { jokeCommand } from './commands/joke';
+import { roryCommand } from "./commands/rory";
 
 import random from 'just-random';
 import { green, bold, yellow, cyan } from 'kleur/colors';
@@ -120,6 +121,8 @@ client.on('interactionCreate', async (interaction) => {
       await tagsCommand(interaction);
     } else if (commandName === 'joke') {
       await jokeCommand(interaction);
+    } else if (commandName === "rory") {
+      await roryCommand(interaction);
     }
   }
 });


### PR DESCRIPTION
The `/rory` command is here!

Inspired by [Chewbotcca's `/rory`](https://github.com/Chewbotcca/Discord/blob/main/src/main/java/pw/chew/chewbotcca/commands/fun/RoryCommand.java), you can type `/rory` for a random Rory, and `/rory id:x` for a specific Rory.

This handles if an error occurs, as well.

This uses the official [Rory API](https://rory.cat/purr), hosted on the official [Rory Website](https://rory.cat). Basically... Rory!!

TypeScript is still not that fun tbh