### PR TITLE
add teawie command

### DIFF
--- a/src/_reupload.ts
+++ b/src/_reupload.ts
@@ -49,9 +49,18 @@ export const reuploadCommands = async () => {
       .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
       .setDMPermission(false),
     new SlashCommandBuilder().setName('joke').setDescription("it's a joke"),
-    new SlashCommandBuilder().setName('rory').setDescription("Gets a Rory photo!")
+    new SlashCommandBuilder()
+      .setName('rory')
+      .setDescription('Gets a Rory photo!')
       .addStringOption((option) =>
-        option.setName("id").setDescription("specify a Rory ID").setRequired(false)),
+        option
+          .setName('id')
+          .setDescription('specify a Rory ID')
+          .setRequired(false)
+      ),
+    new SlashCommandBuilder()
+      .setName('teawie')
+      .setDescription('Gets a random Teawie!'),
   ].map((command) => command.toJSON());
 
   const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN!);

--- a/src/commands/teawie.ts
+++ b/src/commands/teawie.ts
@@ -1,0 +1,42 @@
+import type { CacheType, ChatInputCommandInteraction } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
+
+const teawieApiURL = 'https://guzzle.gay/api';
+
+export interface TeawieResponse {
+  /* The URL to the image of this teawie */
+  url: string;
+}
+
+export const teawieCommand = async (
+  i: ChatInputCommandInteraction<CacheType>
+) => {
+  await i.deferReply();
+
+  const resp: Response = await fetch(teawieApiURL + `/get_random_teawie`, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!resp.ok) {
+    await i.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Error!')
+          .setDescription("Couldn't get a random teawie :("),
+      ],
+    });
+
+    return;
+  }
+
+  const teawie: TeawieResponse = await resp.json();
+
+  await i.editReply({
+    embeds: [
+      new EmbedBuilder()
+        .setTitle('Teawie!')
+        .setURL(teawie.url)
+        .setImage(teawie.url),
+    ],
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ import { starsCommand } from './commands/stars';
 import { modrinthCommand } from './commands/modrinth';
 import { tagsCommand } from './commands/tags';
 import { jokeCommand } from './commands/joke';
-import { roryCommand } from "./commands/rory";
+import { roryCommand } from './commands/rory';
+import { teawieCommand } from './commands/teawie';
 
 import random from 'just-random';
 import { green, bold, yellow, cyan } from 'kleur/colors';
@@ -121,8 +122,10 @@ client.on('interactionCreate', async (interaction) => {
       await tagsCommand(interaction);
     } else if (commandName === 'joke') {
       await jokeCommand(interaction);
-    } else if (commandName === "rory") {
+    } else if (commandName === 'rory') {
       await roryCommand(interaction);
+    } else if (commandName == 'teawie') {
+      await teawieCommand(interaction);
     }
   }
 });


### PR DESCRIPTION
thought it might be cool to have a teawie command here as well after the background got merged into the launcher :)

images are grabbed from my [website](https://guzzle.ay/) running [this](https://github.com/getchoo/guzzle_api) api. the current list of images can be found [here](https://guzzle.gay/api/list_teawies?limit=100) for anyone curious